### PR TITLE
[feature/develop_ph1 -> develop_ph1]存在しないパスを指定された場合Not Foundの画面を出すよう修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { CartPage } from '@/features/cart/routes/CartPage'
 import { CheckoutPage } from '@/features/order/routes/CheckoutPage'
 import { OrderHistoryPage } from '@/features/order/routes/OrderHistoryPage'
 import { LoginPage } from '@/features/auth/routes/LoginPage'
+import { NotFoundPage } from '@/features/error/routes/NotFoundPage'
 
 export default function App() {
   return (
@@ -23,6 +24,7 @@ export default function App() {
               <Route path="/checkout" element={<AuthGuard><CheckoutPage /></AuthGuard>} />
               <Route path="/orders" element={<AuthGuard><OrderHistoryPage /></AuthGuard>} />
               <Route path="/login" element={<LoginPage />} />
+              <Route path="*" element={<NotFoundPage />} />
             </Route>
           </Routes>
         </CartProvider>

--- a/src/features/error/routes/NotFoundPage.test.tsx
+++ b/src/features/error/routes/NotFoundPage.test.tsx
@@ -3,14 +3,20 @@ import { MemoryRouter } from 'react-router-dom'
 import { NotFoundPage } from '@/features/error/routes/NotFoundPage'
 
 describe('NotFoundPage', () => {
-  it('見出しが表示される', () => {
+  it('デフォルトの見出しが表示される', () => {
     render(<NotFoundPage />, { wrapper: MemoryRouter })
-    expect(screen.getByText('お探しの商品は見つかりませんでした。')).toBeInTheDocument()
+    expect(screen.getByText('お探しのページは見つかりませんでした。')).toBeInTheDocument()
   })
 
-  it('説明文が表示される', () => {
+  it('デフォルトの説明文が表示される', () => {
     render(<NotFoundPage />, { wrapper: MemoryRouter })
     expect(screen.getByText('削除されたか、URLが間違っている可能性があります。')).toBeInTheDocument()
+  })
+
+  it('propsで渡したメッセージが表示される', () => {
+    render(<NotFoundPage title="お探しの商品は見つかりませんでした。" description="商品が存在しません。" />, { wrapper: MemoryRouter })
+    expect(screen.getByText('お探しの商品は見つかりませんでした。')).toBeInTheDocument()
+    expect(screen.getByText('商品が存在しません。')).toBeInTheDocument()
   })
 
   it('TOPへ戻るリンクが/を指す', () => {

--- a/src/features/error/routes/NotFoundPage.tsx
+++ b/src/features/error/routes/NotFoundPage.tsx
@@ -1,13 +1,21 @@
 import { BackToTopLink } from '@/features/error/components/BackToTopLink'
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 
-export function NotFoundPage() {
+type Props = {
+  title?: string
+  description?: string
+}
+
+export function NotFoundPage({
+  title = 'お探しのページは見つかりませんでした。',
+  description = '削除されたか、URLが間違っている可能性があります。',
+}: Props = {}) {
   return (
     <div className="max-w-7xl mx-auto px-4 py-6 w-full min-h-[calc(100vh-160px)] flex items-center justify-center">
       <div className="bg-white rounded-2xl shadow-sm p-10 text-center flex flex-col items-center justify-center">
         <MagnifyingGlassIcon className="w-20 h-20 mx-auto mb-6 text-gray-300" strokeWidth={1} />
-        <h2 className="text-lg font-semibold text-gray-800 mb-2">お探しの商品は見つかりませんでした。</h2>
-        <p className="text-sm text-gray-500 mb-8">削除されたか、URLが間違っている可能性があります。</p>
+        <h2 className="text-lg font-semibold text-gray-800 mb-2">{title}</h2>
+        <p className="text-sm text-gray-500 mb-8">{description}</p>
         <BackToTopLink />
       </div>
     </div>


### PR DESCRIPTION
## 404エラーページへのルーティング追加 & NotFoundPageの汎用化

### 概要

存在しないパスにアクセスした際に404エラーページ（NotFoundPage）を表示するようルーティングを追加しました。
また、NotFoundPageのメッセージをpropsで外部から指定できるよう汎用化しました。

### 変更内容

| ファイル | 変更内容 |
|----------|----------|
| `src/App.tsx` | キャッチオールルート（`path="*"`）を追加し、未定義パスでNotFoundPageを表示 |
| `src/features/error/routes/NotFoundPage.tsx` | `title`・`description`をpropsで受け取れるよう変更。デフォルトは汎用メッセージ |
| `src/features/error/routes/NotFoundPage.test.tsx` | デフォルトメッセージ・カスタムpropsのテストケースを追加 |

### 背景・動機

- 未定義のURLにアクセスした場合、空白ページが表示されていたためUX改善として対応
- 商品詳細以外のページでもNotFoundPageを再利用できるよう、メッセージを外だしに変更

### 使用例

```tsx
// デフォルト（汎用メッセージ）
<NotFoundPage />

// 商品ページ向けにカスタマイズ
<NotFoundPage title="お探しの商品は見つかりませんでした。" />
```
