### PR TITLE
[feature/develop_ph1 -> develop_ph1]バックエンドからnullで返されたとき、No Imageとして表示されない

### DIFF
--- a/src/shared/components/Image.test.tsx
+++ b/src/shared/components/Image.test.tsx
@@ -17,4 +17,19 @@ describe('Image', () => {
     fireEvent.error(screen.getByAltText('壊れた画像'))
     expect(screen.getByText('No Image')).toBeInTheDocument()
   })
+
+  it('srcがnullの場合「No Image」が表示される', () => {
+    render(<Image src={null} alt="画像なし" />)
+    expect(screen.getByText('No Image')).toBeInTheDocument()
+  })
+
+  it('srcがundefinedの場合「No Image」が表示される', () => {
+    render(<Image src={undefined} alt="画像なし" />)
+    expect(screen.getByText('No Image')).toBeInTheDocument()
+  })
+
+  it('srcが空文字の場合「No Image」が表示される', () => {
+    render(<Image src="" alt="画像なし" />)
+    expect(screen.getByText('No Image')).toBeInTheDocument()
+  })
 })

--- a/src/shared/components/Image.tsx
+++ b/src/shared/components/Image.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
 
-export function Image({ src, alt, className }: { src: string; alt: string; className?: string }) {
+export function Image({ src, alt, className }: { src: string | null | undefined; alt: string; className?: string }) {
   const [hasError, setHasError] = useState(false)
 
-  if (hasError) {
+  if (!src || hasError) {
     return (
       <div className="h-full w-full bg-gray-100 flex items-center justify-center">
         <span className="text-gray-400 text-sm">No Image</span>

--- a/tmp_check.txt
+++ b/tmp_check.txt
@@ -1,1 +1,0 @@
-.yarn/releases/yarn-4.5.1.cjs


### PR DESCRIPTION
<img width="457" height="784" alt="image" src="https://github.com/user-attachments/assets/acda4698-9ca3-49e4-9d06-aeacb14198ad" />

上記のようにバックエンドから画像のURLのレスポンス項目がnullで返されたとき、NoImageで表示される

## 対応
- null,undefinedの場合、No Imageとして返すよう分岐を追加する