### PR TITLE
[feature/develop_ph1.5 -> develop_ph1.5]画面毎にタイトルを設ける

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>trinity</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/features/auth/routes/LoginPage.tsx
+++ b/src/features/auth/routes/LoginPage.tsx
@@ -41,13 +41,16 @@ export function LoginPage() {
   }
 
   return (
-    <main className="min-h-[70vh] flex items-center justify-center px-4">
-      <div className="w-full max-w-md">
-        <div className="bg-white rounded-2xl shadow-lg p-8">
-          <h1 className="text-2xl font-bold text-gray-900 text-center mb-8">ログイン</h1>
-          <LoginForm onSubmit={handleSubmit} authError={authError} isLoading={isLoading} />
+    <>
+      <title>ログイン | SUNABA</title>
+      <div className="min-h-[70vh] flex items-center justify-center px-4">
+        <div className="w-full max-w-md">
+          <div className="bg-white rounded-2xl shadow-lg p-8">
+            <h1 className="text-2xl font-bold text-gray-900 text-center mb-8">ログイン</h1>
+            <LoginForm onSubmit={handleSubmit} authError={authError} isLoading={isLoading} />
+          </div>
         </div>
       </div>
-    </main>
+    </>
   )
 }

--- a/src/features/cart/components/CartContainer.tsx
+++ b/src/features/cart/components/CartContainer.tsx
@@ -2,8 +2,8 @@ import { type ReactNode } from 'react'
 
 export function CartContainer({ children }: { children: ReactNode }) {
   return (
-    <main className="max-w-4xl mx-auto px-4 py-8">
+    <div className="max-w-4xl mx-auto px-4 py-8">
       {children}
-    </main>
+    </div>
   )
 }

--- a/src/features/cart/routes/CartPage.tsx
+++ b/src/features/cart/routes/CartPage.tsx
@@ -18,30 +18,36 @@ export function CartPage() {
 
   if (items.length === 0) {
     return (
-      <CartContainer>
-        <div className="bg-white rounded-xl shadow-sm p-12 text-center">
-          <ShoppingCartIcon className="w-16 h-16 mx-auto mb-4 text-gray-300" strokeWidth={1} />
-          <p className="text-gray-500 text-lg">カートに商品がありません</p>
-          <ActionButton to="/" label="お買い物を続ける →" className="mt-4 inline-block w-auto px-6 py-2" />
-        </div>
-      </CartContainer>
+      <>
+        <title>買い物かご一覧 | SUNABA</title>
+        <CartContainer>
+          <div className="bg-white rounded-xl shadow-sm p-12 text-center">
+            <ShoppingCartIcon className="w-16 h-16 mx-auto mb-4 text-gray-300" strokeWidth={1} />
+            <p className="text-gray-500 text-lg">カートに商品がありません</p>
+            <ActionButton to="/" label="お買い物を続ける →" className="mt-4 inline-block w-auto px-6 py-2" />
+          </div>
+        </CartContainer>
+      </>
     )
   }
 
   return (
-    <CartContainer>
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">ショッピングカート <span className="text-gray-500 text-lg font-normal">({items.length}件)</span></h1>
+    <>
+      <title>買い物かご一覧 | SUNABA</title>
+      <CartContainer>
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">ショッピングカート <span className="text-gray-500 text-lg font-normal">({items.length}件)</span></h1>
 
-      <div className="bg-white rounded-xl shadow-sm divide-y divide-gray-300">
-        {items.map(item => (
-          <CartItemCard key={item.productId} item={item} onUpdateQuantity={updateQuantity} onRemove={removeItem} />
-        ))}
-      </div>
+        <div className="bg-white rounded-xl shadow-sm divide-y divide-gray-300">
+          {items.map(item => (
+            <CartItemCard key={item.productId} item={item} onUpdateQuantity={updateQuantity} onRemove={removeItem} />
+          ))}
+        </div>
 
-      <div className="mt-6 bg-white rounded-xl shadow-sm p-6">
-        <OrderSummary totalPrice={totalPrice} />
-        <ActionButton onClick={handleCheckout} label="注文手続きへ進む →" className="mt-4" />
-      </div>
-    </CartContainer>
+        <div className="mt-6 bg-white rounded-xl shadow-sm p-6">
+          <OrderSummary totalPrice={totalPrice} />
+          <ActionButton onClick={handleCheckout} label="注文手続きへ進む →" className="mt-4" />
+        </div>
+      </CartContainer>
+    </>
   )
 }

--- a/src/features/error/routes/NotFoundPage.tsx
+++ b/src/features/error/routes/NotFoundPage.tsx
@@ -11,13 +11,16 @@ export function NotFoundPage({
   description = '削除されたか、URLが間違っている可能性があります。',
 }: Props = {}) {
   return (
-    <div className="max-w-7xl mx-auto px-4 py-6 w-full min-h-[calc(100vh-160px)] flex items-center justify-center">
-      <div className="bg-white rounded-2xl shadow-sm p-10 text-center flex flex-col items-center justify-center">
-        <MagnifyingGlassIcon className="w-20 h-20 mx-auto mb-6 text-gray-300" strokeWidth={1} />
-        <h2 className="text-lg font-semibold text-gray-800 mb-2">{title}</h2>
-        <p className="text-sm text-gray-500 mb-8">{description}</p>
-        <BackToTopLink />
+    <>
+      <title>ページが見つかりません | SUNABA</title>
+      <div className="max-w-7xl mx-auto px-4 py-6 w-full min-h-[calc(100vh-160px)] flex items-center justify-center">
+        <div className="bg-white rounded-2xl shadow-sm p-10 text-center flex flex-col items-center justify-center">
+          <MagnifyingGlassIcon className="w-20 h-20 mx-auto mb-6 text-gray-300" strokeWidth={1} />
+          <h2 className="text-lg font-semibold text-gray-800 mb-2">{title}</h2>
+          <p className="text-sm text-gray-500 mb-8">{description}</p>
+          <BackToTopLink />
+        </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/features/error/routes/ServerErrorPage.tsx
+++ b/src/features/error/routes/ServerErrorPage.tsx
@@ -5,19 +5,22 @@ import { ArrowPathIcon } from '@heroicons/react/20/solid'
 
 export function ServerErrorPage({ onRetry }: { onRetry: () => void }) {
   return (
-    <div className="max-w-7xl mx-auto px-4 py-6 w-full min-h-[calc(100vh-160px)] flex items-center justify-center">
-      <div className="bg-white rounded-2xl shadow-sm p-10 text-center flex flex-col items-center justify-center">
-        <ExclamationTriangleIcon className="w-20 h-20 mx-auto mb-6 text-amber-400" strokeWidth={1} />
-        <h2 className="text-lg font-semibold text-gray-800 mb-2">エラーが発生しました</h2>
-        <p className="text-sm text-gray-500 mb-8">しばらく時間をおいて再度お試しください。</p>
-        <div className="flex flex-col gap-3 items-center">
-          <Button onClick={onRetry} variant="primary" size="sm">
-            <ArrowPathIcon className="w-4 h-4" />
-            再読み込み
-          </Button>
-          <BackToTopLink />
+    <>
+      <title>エラーが発生しました | SUNABA</title>
+      <div className="max-w-7xl mx-auto px-4 py-6 w-full min-h-[calc(100vh-160px)] flex items-center justify-center">
+        <div className="bg-white rounded-2xl shadow-sm p-10 text-center flex flex-col items-center justify-center">
+          <ExclamationTriangleIcon className="w-20 h-20 mx-auto mb-6 text-amber-400" strokeWidth={1} />
+          <h2 className="text-lg font-semibold text-gray-800 mb-2">エラーが発生しました</h2>
+          <p className="text-sm text-gray-500 mb-8">しばらく時間をおいて再度お試しください。</p>
+          <div className="flex flex-col gap-3 items-center">
+            <Button onClick={onRetry} variant="primary" size="sm">
+              <ArrowPathIcon className="w-4 h-4" />
+              再読み込み
+            </Button>
+            <BackToTopLink />
+          </div>
         </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/features/home/routes/TopPage.tsx
+++ b/src/features/home/routes/TopPage.tsx
@@ -24,6 +24,7 @@ export function TopPage() {
 
   return (
     <>
+      <title>SUNABA - 通販サイト</title>
       <HeroBanner />
       <ProductSection title="おすすめ商品" products={recommended} isLoading={loadingRecommended} />
       <div className="mb-16">

--- a/src/features/order/components/OrderCompleteCard.tsx
+++ b/src/features/order/components/OrderCompleteCard.tsx
@@ -3,7 +3,7 @@ import { CheckCircleIcon } from '@heroicons/react/24/solid'
 
 export function OrderCompleteCard() {
   return (
-    <main className="max-w-2xl mx-auto px-4 py-8">
+    <div className="max-w-2xl mx-auto px-4 py-8">
       <div className="bg-white rounded-xl shadow-sm p-10 text-center">
         <div className="w-16 h-16 bg-brand-100 rounded-full flex items-center justify-center mx-auto mb-4">
           <CheckCircleIcon className="w-10 h-10 text-brand-600" />
@@ -15,6 +15,6 @@ export function OrderCompleteCard() {
           <Link to="/orders" className="bg-brand-600 text-white px-6 py-2 rounded-lg hover:bg-brand-700 transition">注文履歴を見る</Link>
         </div>
       </div>
-    </main>
+    </div>
   )
 }

--- a/src/features/order/components/OrderHistoryContainer.tsx
+++ b/src/features/order/components/OrderHistoryContainer.tsx
@@ -2,9 +2,9 @@ import { type ReactNode } from 'react'
 
 export function OrderHistoryContainer({ children }: { children: ReactNode }) {
   return (
-    <main className="max-w-3xl mx-auto px-4 py-8">
+    <div className="max-w-3xl mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold text-gray-900 mb-6">注文履歴</h1>
       {children}
-    </main>
+    </div>
   )
 }

--- a/src/features/order/routes/CheckoutPage.tsx
+++ b/src/features/order/routes/CheckoutPage.tsx
@@ -47,7 +47,12 @@ export function CheckoutPage() {
   }
 
   if (ordered) {
-    return <OrderCompleteCard />
+    return (
+      <>
+        <title>購入完了 | SUNABA</title>
+        <OrderCompleteCard />
+      </>
+    )
   }
 
   if (items.length === 0) {
@@ -55,26 +60,29 @@ export function CheckoutPage() {
   }
 
   return (
-    <main className="max-w-4xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">注文内容の確認</h1>
+    <>
+      <title>購入確認 | SUNABA</title>
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold text-gray-900 mb-6">注文内容の確認</h1>
 
-      <OrderItemsCard items={items} totalPrice={totalPrice} />
+        <OrderItemsCard items={items} totalPrice={totalPrice} />
 
-      <SubmitButton
-        onClick={handleOrder}
-        label="注文を確定する"
-        loadingLabel="処理中..."
-        isLoading={loading}
-        className="mt-6"
-      />
-
-      {error && (
-        <OrderErrorCard
-          message={error.message}
-          isProductError={!!(error.code && ORDER_ERROR_CODES.includes(error.code as typeof ORDER_ERROR_CODES[number]))}
-          onRetry={handleOrder}
+        <SubmitButton
+          onClick={handleOrder}
+          label="注文を確定する"
+          loadingLabel="処理中..."
+          isLoading={loading}
+          className="mt-6"
         />
-      )}
-    </main>
+
+        {error && (
+          <OrderErrorCard
+            message={error.message}
+            isProductError={!!(error.code && ORDER_ERROR_CODES.includes(error.code as typeof ORDER_ERROR_CODES[number]))}
+            onRetry={handleOrder}
+          />
+        )}
+      </div>
+    </>
   )
 }

--- a/src/features/order/routes/OrderHistoryPage.tsx
+++ b/src/features/order/routes/OrderHistoryPage.tsx
@@ -84,6 +84,7 @@ export function OrderHistoryPage() {
 
   return (
     <>
+      <title>購入履歴一覧 | SUNABA</title>
       {toast && <Toast toast={toast} onClose={() => setToast(null)} />}
       <OrderHistoryContainer>
         <div className="space-y-4">

--- a/src/features/product/routes/ProductDetailPage.tsx
+++ b/src/features/product/routes/ProductDetailPage.tsx
@@ -58,9 +58,10 @@ export function ProductDetailPage() {
 
   return (
     <>
+      <title>{`${product.product_name} | SUNABA`}</title>
       {toast && <Toast toast={toast} onClose={closeToast} />}
 
-      <main className="max-w-7xl mx-auto px-4 py-6">
+      <div className="max-w-7xl mx-auto px-4 py-6">
         <Breadcrumb productName={product.product_name} />
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
@@ -98,28 +99,31 @@ export function ProductDetailPage() {
             </div>
           </div>
         </div>
-      </main>
+      </div>
     </>
   )
 }
 
 function Skeleton() {
   return (
-    <main className="max-w-7xl mx-auto px-4 py-6">
-      <div className="animate-pulse h-4 w-40 bg-gray-200 rounded mb-6" />
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
-        <div className="animate-pulse bg-gray-200 rounded-2xl aspect-square" />
-        <div className="space-y-4">
-          <div className="animate-pulse h-8 w-3/4 bg-gray-200 rounded" />
-          <div className="animate-pulse h-10 w-1/3 bg-gray-200 rounded" />
-          <div className="animate-pulse h-4 w-1/2 bg-gray-200 rounded" />
-          <div className="animate-pulse h-px w-full bg-gray-200" />
-          <div className="animate-pulse h-10 w-40 bg-gray-200 rounded" />
-          <div className="animate-pulse h-12 w-full bg-gray-200 rounded-lg" />
-          <div className="animate-pulse h-px w-full bg-gray-200" />
-          <div className="animate-pulse h-20 bg-gray-200 rounded" />
+    <>
+      <title>商品詳細 | SUNABA</title>
+      <div className="max-w-7xl mx-auto px-4 py-6">
+        <div className="animate-pulse h-4 w-40 bg-gray-200 rounded mb-6" />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
+          <div className="animate-pulse bg-gray-200 rounded-2xl aspect-square" />
+          <div className="space-y-4">
+            <div className="animate-pulse h-8 w-3/4 bg-gray-200 rounded" />
+            <div className="animate-pulse h-10 w-1/3 bg-gray-200 rounded" />
+            <div className="animate-pulse h-4 w-1/2 bg-gray-200 rounded" />
+            <div className="animate-pulse h-px w-full bg-gray-200" />
+            <div className="animate-pulse h-10 w-40 bg-gray-200 rounded" />
+            <div className="animate-pulse h-12 w-full bg-gray-200 rounded-lg" />
+            <div className="animate-pulse h-px w-full bg-gray-200" />
+            <div className="animate-pulse h-20 bg-gray-200 rounded" />
+          </div>
         </div>
       </div>
-    </main>
+    </>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -27,6 +27,10 @@
 
 
 
+html {
+  scrollbar-gutter: stable;
+}
+
 body {
   font-family: 'Segoe UI', 'Hiragino Sans', sans-serif;
 }


### PR DESCRIPTION
画面毎のタイトルページがあまりに簡素なため、要件に基づき各種ページのタイトルをつける
なお、現在のReactのバージョンではデフォルトでtitleタグをつけて書き換えができるため、helmetは使用しない

## 画面毎のタイトル表記を以下に合わせる

- SUNABA - 通販サイト
- ログイン | SUNABA
- 商品名 | SUNABA
- 買い物かご一覧 | SUNABA
- 購入確認 | SUNABA
- 購入完了 | SUNABA
- 購入履歴一覧 | SUNABA

※ タイトルを変える中でヘッダーの検索バーのずれを確認しているため一部スタイルの修正も併せて実施