### PR TITLE
[feature/develop_ph1.5 -> develop_ph1.5]ログイン後はログインページに遷移できないようにする

### DIFF
--- a/src/features/auth/routes/LoginPage.test.tsx
+++ b/src/features/auth/routes/LoginPage.test.tsx
@@ -31,10 +31,38 @@ describe('LoginPage', () => {
     mockFetchMe.mockResolvedValue({ success: true, data: null })
   })
 
-  describe('画面表示', () => {
-    it('ログインタイトルが表示される', () => {
+  describe('認証済みリダイレクト', () => {
+    it('ログイン済みの場合はTOP画面にリダイレクトされる', async () => {
+      mockFetchMe.mockResolvedValue({
+        success: true,
+        data: { userId: 1, userName: 'Taro', email: 'taro@example.com' },
+      })
       renderLoginPage()
-      expect(screen.getByRole('heading', { name: 'ログイン' })).toBeInTheDocument()
+
+      await waitFor(() => {
+        expect(screen.getByText('TOPページ')).toBeInTheDocument()
+      })
+    })
+
+    it('ログイン済みの場合はログインフォームが表示されない', async () => {
+      mockFetchMe.mockResolvedValue({
+        success: true,
+        data: { userId: 1, userName: 'Taro', email: 'taro@example.com' },
+      })
+      renderLoginPage()
+
+      await waitFor(() => {
+        expect(screen.queryByRole('heading', { name: 'ログイン' })).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('画面表示', () => {
+    it('ログインタイトルが表示される', async () => {
+      renderLoginPage()
+      await waitFor(() => {
+        expect(screen.getByRole('heading', { name: 'ログイン' })).toBeInTheDocument()
+      })
     })
   })
 
@@ -42,12 +70,13 @@ describe('LoginPage', () => {
     it('ログイン成功後にTOP画面へ遷移する', async () => {
       const user = userEvent.setup()
       mockLogin.mockResolvedValue({ success: true, data: { user_name: 'Taro' } })
-      mockFetchMe.mockResolvedValue({
+      mockFetchMe.mockResolvedValueOnce({ success: true, data: null }).mockResolvedValue({
         success: true,
         data: { userId: 1, userName: 'Taro', email: 'taro@example.com' },
       })
       renderLoginPage()
 
+      await waitFor(() => expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument())
       await user.type(screen.getByLabelText('メールアドレス'), 'taro@example.com')
       await user.type(screen.getByLabelText('パスワード'), 'password123')
       await user.click(screen.getByRole('button', { name: 'ログイン' }))
@@ -60,12 +89,13 @@ describe('LoginPage', () => {
     it('ログインAPIにemail/passwordが送信される', async () => {
       const user = userEvent.setup()
       mockLogin.mockResolvedValue({ success: true, data: { user_name: 'Taro' } })
-      mockFetchMe.mockResolvedValue({
+      mockFetchMe.mockResolvedValueOnce({ success: true, data: null }).mockResolvedValue({
         success: true,
         data: { userId: 1, userName: 'Taro', email: 'taro@example.com' },
       })
       renderLoginPage()
 
+      await waitFor(() => expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument())
       await user.type(screen.getByLabelText('メールアドレス'), 'taro@example.com')
       await user.type(screen.getByLabelText('パスワード'), 'password123')
       await user.click(screen.getByRole('button', { name: 'ログイン' }))
@@ -81,6 +111,7 @@ describe('LoginPage', () => {
       mockFetchMe.mockResolvedValue({ success: true, data: null })
       renderLoginPage()
 
+      await waitFor(() => expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument())
       await user.type(screen.getByLabelText('メールアドレス'), 'taro@example.com')
       await user.type(screen.getByLabelText('パスワード'), 'password123')
       await user.click(screen.getByRole('button', { name: 'ログイン' }))
@@ -97,6 +128,7 @@ describe('LoginPage', () => {
       mockLogin.mockResolvedValue({ success: false, errorCode: 'API_LOGIN_ERR001', message: 'invalid password or email' })
       renderLoginPage()
 
+      await waitFor(() => expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument())
       await user.type(screen.getByLabelText('メールアドレス'), 'taro@example.com')
       await user.type(screen.getByLabelText('パスワード'), 'wrong')
       await user.click(screen.getByRole('button', { name: 'ログイン' }))
@@ -111,6 +143,7 @@ describe('LoginPage', () => {
       mockLogin.mockResolvedValue({ success: false, errorCode: 'API_LOGIN_ERR001', message: 'invalid password or email' })
       renderLoginPage()
 
+      await waitFor(() => expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument())
       await user.type(screen.getByLabelText('メールアドレス'), 'taro@example.com')
       await user.type(screen.getByLabelText('パスワード'), 'wrong')
       await user.click(screen.getByRole('button', { name: 'ログイン' }))
@@ -128,6 +161,7 @@ describe('LoginPage', () => {
       mockLogin.mockResolvedValue({ success: false, errorCode: 'API_ERR999', message: 'server error.' })
       renderLoginPage()
 
+      await waitFor(() => expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument())
       await user.type(screen.getByLabelText('メールアドレス'), 'taro@example.com')
       await user.type(screen.getByLabelText('パスワード'), 'password123')
       await user.click(screen.getByRole('button', { name: 'ログイン' }))
@@ -142,6 +176,7 @@ describe('LoginPage', () => {
       mockLogin.mockResolvedValue({ success: false, errorCode: null, message: null })
       renderLoginPage()
 
+      await waitFor(() => expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument())
       await user.type(screen.getByLabelText('メールアドレス'), 'taro@example.com')
       await user.type(screen.getByLabelText('パスワード'), 'password123')
       await user.click(screen.getByRole('button', { name: 'ログイン' }))
@@ -156,6 +191,7 @@ describe('LoginPage', () => {
       mockLogin.mockResolvedValue({ success: false, errorCode: 'API_ERR999', message: 'server error.' })
       renderLoginPage()
 
+      await waitFor(() => expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument())
       await user.type(screen.getByLabelText('メールアドレス'), 'taro@example.com')
       await user.type(screen.getByLabelText('パスワード'), 'password123')
       await user.click(screen.getByRole('button', { name: 'ログイン' }))
@@ -176,6 +212,7 @@ describe('LoginPage', () => {
       mockLogin.mockReturnValue(new Promise(() => {}))
       renderLoginPage()
 
+      await waitFor(() => expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument())
       await user.type(screen.getByLabelText('メールアドレス'), 'taro@example.com')
       await user.type(screen.getByLabelText('パスワード'), 'password123')
       await user.click(screen.getByRole('button', { name: 'ログイン' }))

--- a/src/features/auth/routes/LoginPage.tsx
+++ b/src/features/auth/routes/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavigate, useLocation, Navigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
 import { login } from '@/services/userService'
 import { ErrorCode } from '@/types/api'
@@ -9,16 +9,16 @@ import { ServerErrorPage } from '@/features/error/routes/ServerErrorPage'
 export function LoginPage() {
   const navigate = useNavigate()
   const location = useLocation()
-  const { login: setAuthUser, refreshUser } = useAuth()
+  const { login: setAuthUser, refreshUser, isAuthenticated, isLoading } = useAuth()
 
   const [authError, setAuthError] = useState('')
-  const [isLoading, setIsLoading] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const [isServerError, setIsServerError] = useState(false)
 
   const handleSubmit = async (email: string, password: string) => {
     setAuthError('')
     setIsServerError(false)
-    setIsLoading(true)
+    setIsSubmitting(true)
     const result = await login({ email, password })
     if (result.success) {
       const user = await refreshUser()
@@ -33,12 +33,15 @@ export function LoginPage() {
     } else {
       setIsServerError(true)
     }
-    setIsLoading(false)
+    setIsSubmitting(false)
   }
 
   if (isServerError) {
     return <ServerErrorPage onRetry={() => setIsServerError(false)} />
   }
+
+  if (isLoading) return null
+  if (isAuthenticated) return <Navigate to="/" replace />
 
   return (
     <>
@@ -47,7 +50,7 @@ export function LoginPage() {
         <div className="w-full max-w-md">
           <div className="bg-white rounded-2xl shadow-lg p-8">
             <h1 className="text-2xl font-bold text-gray-900 text-center mb-8">ログイン</h1>
-            <LoginForm onSubmit={handleSubmit} authError={authError} isLoading={isLoading} />
+            <LoginForm onSubmit={handleSubmit} authError={authError} isLoading={isSubmitting} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
ログイン後、直接loginページをたたくとログイン済みでもページ遷移ができてしまう
本来の要件にないが、検討の結果このタイミングで合わせて直すものとする